### PR TITLE
Include AppArmor Abstractions

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -8,6 +8,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   #include <abstractions/gnome>
   #include <abstractions/ibus>
   #include if exists <abstractions/vulkan>
+  #include if exists <abstractions/dbus-session>
 
   # Uncomment the following lines if you want to give the Tor Browser read-write
   # access to most of your personal files.

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -9,6 +9,17 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   #include <abstractions/ibus>
   #include if exists <abstractions/vulkan>
   #include if exists <abstractions/dbus-session>
+  #include if exists <abstractions/X>
+  
+  # In Ubuntu 21.04 and later, there is a change to the X abstractions that will
+  # deny access to writing to the X display socket. This means that, even if we
+  # include the X abstractions, we won't be able to spin up the Firefox browser 
+  # on any non-GNOME environment which doesn't include the X read/write abstractions.
+  # 
+  # See https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/1934005
+  # Override the apparmor abstractions bit to permit readwrite on the
+  # X display sockets for now, though, so that Tor Browser can actually run.
+  /tmp/.X11-unix/* rw,
 
   # Uncomment the following lines if you want to give the Tor Browser read-write
   # access to most of your personal files.

--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -10,16 +10,6 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
   #include if exists <abstractions/vulkan>
   #include if exists <abstractions/dbus-session>
   #include if exists <abstractions/X>
-  
-  # In Ubuntu 21.04 and later, there is a change to the X abstractions that will
-  # deny access to writing to the X display socket. This means that, even if we
-  # include the X abstractions, we won't be able to spin up the Firefox browser 
-  # on any non-GNOME environment which doesn't include the X read/write abstractions.
-  # 
-  # See https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/1934005
-  # Override the apparmor abstractions bit to permit readwrite on the
-  # X display sockets for now, though, so that Tor Browser can actually run.
-  /tmp/.X11-unix/* rw,
 
   # Uncomment the following lines if you want to give the Tor Browser read-write
   # access to most of your personal files.


### PR DESCRIPTION
Fixes #588.

The apparmor rules that are introduced break a few things by not including required abstractions.

 - There are DBUS denies for opening dialog boxes and file open boxes, which need DBUS abstractions to access the user sessions.  Fixed by including `abstractions/dbus-session` (which also implicitly imports `abstractions/dbus-session-strict` for SystemD user sessions) in the apparmor rules, if the abstractions exist.
 - There are X abstractions which are useful and needed for X display integration.  So if those abstractions exist, include them.  HOWEVER, there's a problem in Ubuntu where these abstractions are *not* properly handling the X Display Sockets in `/tmp/.X11-unix/*` so we need to permit those with a specific override.  See the comment block in the profile for details.