### PR TITLE
Add connection and read timeouts to requests to prevent app hangs.

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -311,20 +311,24 @@ class Common(object):
         # p.wait()
 
         # Download the key from WKD directly
-        r = requests.get(
-            "https://torproject.org/.well-known/openpgpkey/hu/kounek7zrdx745qydx6p59t9mqjpuhdf?l=torbrowser",
-            proxies=self.proxies(),
-        )
-        if r.status_code != 200:
-            print(f"Error fetching key, status code = {r.status_code}")
-        else:
-            with open(self.paths["signing_keys"]["wkd_tmp"], "wb") as f:
-                f.write(r.content)
+        try:
+            r = requests.get(
+                "https://torproject.org/.well-known/openpgpkey/hu/kounek7zrdx745qydx6p59t9mqjpuhdf?l=torbrowser",
+                proxies=self.proxies(),
+                timeout=5,
+            )
+            r.raise_for_status()
+        except requests.RequestException as e:
+            print(f"Error fetching key, status code = {e.response.status_code}")
+            return
 
-            if self.import_key_and_check_status("wkd_tmp"):
-                print("Key imported successfully")
-            else:
-                print("Key failed to import")
+        with open(self.paths["signing_keys"]["wkd_tmp"], "wb") as f:
+            f.write(r.content)
+
+        if self.import_key_and_check_status("wkd_tmp"):
+            print("Key imported successfully")
+        else:
+            print("Key failed to import")
 
     def import_key_and_check_status(self, key):
         """Import a GnuPG key and check that the operation was successful.

--- a/torbrowser_launcher/launcher.py
+++ b/torbrowser_launcher/launcher.py
@@ -602,7 +602,6 @@ class DownloadThread(QtCore.QThread):
                 else:
                     message = (_("Download Error:") + " {0}").format(e.response.status_code)
                     self.download_error.emit("error", message)
-                return
 
             except requests.exceptions.SSLError:
                 message = _(
@@ -613,7 +612,6 @@ class DownloadThread(QtCore.QThread):
                     self.download_error.emit("error_try_tor", message)
                 else:
                     self.download_error.emit("error", message)
-                return
 
             except requests.exceptions.ConnectionError:
                 # Connection error
@@ -628,8 +626,6 @@ class DownloadThread(QtCore.QThread):
                         "Error starting download:\n\n{0}\n\nAre you connected to the internet?"
                     ).format(self.url.decode())
                     self.download_error.emit("error", message)
-
-                return
 
         self.download_complete.emit()
 


### PR DESCRIPTION
### Issue

We currently make two requests that have no timeout. These could potentially block the application forever if there are network or server issues. The `requests` library [recommends](https://docs.python-requests.org/en/master/user/quickstart/#timeouts) _all_ production code [utilize timeouts](https://docs.python-requests.org/en/latest/user/advanced/#timeouts) for this reason.

### Proposed Solution

I add a five second timeout to the two requests in `common.py` and `launcher.py` as well as a custom HTTP adapter that retries failed requests up to three times.

### Implementation Details

I implement a custom `HTTPAdapter` which configures a max of three retries in the event of a connection issue. Since this retry strategy has to be implemented via an `HTTPAdapter` I also had to implement a `requests.Session()` attribute on the two classes in question `torbrowser_launcher.common.Common` and `torbrowser_launcher.launcher.DownloadThread`, then mount that adapter to the `Session()`. This `session` is then used to make the GET request.

Also, instead of the if/else logic checking for a 200 status code on the response, I utilize the `raise_for_status()` method on the response object. If the response is not a 200 OK, this will raise a `requests.HTTPError`. I then move the error handling logic intended for that situation into a handler for that exception where, I would argue, it belongs.

### Exception Handling

In the event of a timeout, the `requests` library will raise either a [`ConnectTimeout`](https://docs.python-requests.org/en/master/_modules/requests/exceptions/#ConnectTimeout) or a [`ReadTimeout`](https://docs.python-requests.org/en/master/_modules/requests/exceptions/#ReadTimeout), both of which are subclasses of `Timeout` and in the case of `ConnectTimeout` it is also subclasses `ConnectionError` (see linked docs).

In the case of the download timing out in `launcher.py`, if it was a `ConnectTimeout` the existing error handling for `ConnectionError` will execute. In the event it was a `ReadTimeout` an unhandled exception would occur.

An open question is if we want a `ReadTimeout` to be unhandled or if we should gracefully handle a `ReadTimeout` differently or perhaps even just have the handler for `ConnectionError` also handle `ReadTimeout`? The existing error language for a `ConnectionError` here works well in the event there was a `ConnectTimeout`. It is less accurate if there was a `ReadTimeout` e.g. we made a connection successfully but the server failed to send us data in the specified timeframe. In such a case we probably don't want to say "Error **starting** download..." which is why I hesitate to just handle `ConnectionError` and `Timeout` together here. Maybe we can do that and just edit the "starting" language to be something more general like "Error while downloading"?

In `common.Common` I just follow the existing strategy of printing an error to the console if there's a request exception. In this case, I catch either type of timeout by catching `requests.Timeout`.