### PR TITLE
Depend on dbus-glib

### DIFF
--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -6,7 +6,7 @@ VERSION=$(cat share/torbrowser-launcher/version)
 rm -r build dist
 
 # build binary package
-python3 setup.py bdist_rpm --requires="python3-qt5, python3-gpg, python3-requests, python3-pysocks, python3-packaging, gnupg2"
+python3 setup.py bdist_rpm --requires="python3-qt5, python3-gpg, python3-requests, python3-pysocks, python3-packaging, gnupg2, dbus-glib"
 
 # install it
 echo ""


### PR DESCRIPTION
Tor Browser needs dbus-glib to be installed on the system. Currently, the Fedora/RPM package does not include this dependency, which can result in the downloaded Tor Browser silently failing to run. This PR adds this dependency to build_rpm.sh.