### PR TITLE
Fix path variables in AppArmor profile

### DIFF
--- a/apparmor/torbrowser.Browser.firefox
+++ b/apparmor/torbrowser.Browser.firefox
@@ -1,7 +1,7 @@
 #include <tunables/global>
 #include <tunables/torbrowser>
 
-@{torbrowser_firefox_executable} = /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/firefox.real
+@{torbrowser_firefox_executable} = /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser/Browser/firefox.real
 
 profile torbrowser_firefox @{torbrowser_firefox_executable} {
   #include <abstractions/audio>

--- a/apparmor/torbrowser.Tor.tor
+++ b/apparmor/torbrowser.Tor.tor
@@ -1,7 +1,7 @@
 #include <tunables/global>
 #include <tunables/torbrowser>
 
-@{torbrowser_tor_executable} = /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*/Browser/TorBrowser/Tor/tor
+@{torbrowser_tor_executable} = /home/*/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser/Browser/TorBrowser/Tor/tor
 
 profile torbrowser_tor @{torbrowser_tor_executable} {
   #include <abstractions/base>

--- a/apparmor/tunables/torbrowser
+++ b/apparmor/tunables/torbrowser
@@ -1,2 +1,2 @@
-@{torbrowser_installation_dir}=@{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser_*
+@{torbrowser_installation_dir}=@{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser
 @{torbrowser_home_dir}=@{torbrowser_installation_dir}/Browser


### PR DESCRIPTION
Tor Browser is installed to `@{HOME}/.local/share/torbrowser/tbb/{i686,x86_64}/tor-browser` since #661, but AppArmor profiles are never updated to that path.

This pull request update these variables to the current installation directory.