### PR TITLE
Use raw string literal for regex in common.py

### DIFF
--- a/torbrowser_launcher/common.py
+++ b/torbrowser_launcher/common.py
@@ -47,7 +47,7 @@ gettext.install("torbrowser-launcher")
 #  2. The second must be an integer between [0, 15], inclusive
 #  3. The third must be an uppercased hex-encoded 160-bit fingerprint
 gnupg_import_ok_pattern = re.compile(
-    b"(\[GNUPG\:\]) (IMPORT_OK) ([0-9]|[1]?[0-5]) ([A-F0-9]{40})"
+    rb"(\[GNUPG\:\]) (IMPORT_OK) ([0-9]|[1]?[0-5]) ([A-F0-9]{40})"
 )
 
 


### PR DESCRIPTION
When installing torbrowser-launcher using a package manager, the following warnings arise:

```
...
Byte-compiling python3.12 code for module torbrowser_launcher...
usr/lib/python3.12/site-packages/torbrowser_launcher/common.py:50: SyntaxWarning: invalid escape sequence '\['
  b"(\[GNUPG\:\]) (IMPORT_OK) ([0-9]|[1]?[0-5]) ([A-F0-9]{40})"
usr/lib/python3.12/site-packages/torbrowser_launcher/common.py:50: SyntaxWarning: invalid escape sequence '\['
  b"(\[GNUPG\:\]) (IMPORT_OK) ([0-9]|[1]?[0-5]) ([A-F0-9]{40})"
...
```

Switching this string literal to a raw string literal should fix the issue.