### PR TITLE
Add a pyproject.toml for PEP-517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "torbrowser-launcher"
+dynamic = ["version", "description", "dependencies", "authors", "license", "readme"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     version=version,
     author="Micah Lee",
     author_email="micah@micahflee.com",
-    url="https://www.github.com/micahflee/torbrowser-launcher",
+    url="https://www.github.com/torproject/torbrowser-launcher",
     platforms=["GNU/Linux"],
     license="MIT",
     description="A program to help you securely download and run Tor Browser",


### PR DESCRIPTION
This configures pyproject.toml to read from `setup.py`. One caveat I've noticed, the apparmor profile is getting installed to `/usr/lib/python3.11/site-packages/etc` instead of `/etc`, not sure how to fix this.